### PR TITLE
Fix lib folder linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 ### Fixed (workflow)
 
 * **FIX** fixed optimisation tolerance of hydro power plants from xtol to xatol (#266).
+* **FIX** fixed lib folder linking when moving the workflow folder.
 
 ## 1.1.0 (2021-12-22)
 

--- a/Snakefile
+++ b/Snakefile
@@ -44,10 +44,12 @@ def ensure_lib_folder_is_linked():
     if not workflow.deployment_settings.conda_prefix:
         return
     link = Path(workflow.deployment_settings.conda_prefix) / "lib"
-    if not link.exists():
+    if not link.exists():  # Returns False if link exists but is an invalid symlink
         print("Creating link from conda env dir to eurocalliopelib.")
+        if link.is_symlink():  # Deal with existing but invalid symlink
+            shell(f"rm {link}")
         makedirs(workflow.deployment_settings.conda_prefix)
-        shell(f"ln -s {workflow.basedir}/lib {workflow.deployment_settings.conda_prefix}/lib")
+        shell(f"ln -s {workflow.basedir}/lib {link}")
 
 
 ensure_lib_folder_is_linked()


### PR DESCRIPTION
Fixes an issue where symlink creation fails if the euro-calliope folder was moved after initial run.

## Checklist

Any checks which are not relevant to the PR can be pre-checked by the PR creator. All others should be checked by the reviewer. You can add extra checklist items here if required by the PR.

- [ ] CHANGELOG updated
- [ ] Minimal workflow tests pass
- [ ] Tests added to cover contribution
- [ ] Documentation updated
- [ ] Configuration schema updated
